### PR TITLE
Use normal file instead of symlink

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,1 +1,2 @@
-CHANGES.md
+See CHANGES.md
+


### PR DESCRIPTION
Getting a build error on Windows (specifically:
https://dev.azure.com/yawaramin/re-web/_build/results?buildId=23&view=logs&j=bc6600a8-aabf-5f52-8880-429735df640c&t=667398e1-191a-5be5-68f0-b1dc1df96fae ),
hoping this fixes it.